### PR TITLE
make ssh port a configurable option, default 222, chown crl.pem

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ module "my_openvpn" {
 - `ip` - **[type: list]** List of private IP address of the OpenVPN instance.
 - `security_group` - **[type: string]** ID of the security group to be added to every instance that should allow access from the OpenVPN service.
 - `ssh_key` - **[type: string]** The name of the SSH key used.
+- `ssh_port` -  **[type: string]** The SSH access port.
 
 ## Service Access
 
@@ -93,11 +94,11 @@ This modules provides a security group that will allow access from the OpenVPN
 instance.
 
 That group will allow access to the following ports to all the AWS EC2
-instances that belong to the group:
+instances that belong to the group.  Note that by default, the original packer image uses port 222 for SSH access.
 
 | Service    | Port   | Protocol |
 |:-----------|:------:|:--------:|
-| SSH        | 22     |    TCP   |
+| SSH        | 222    |    TCP   |
 | OpenVPN    | 1194   |    UDP   |
 
 If access to other ports is required, you can create your own security group

--- a/main.tf
+++ b/main.tf
@@ -85,8 +85,8 @@ resource "aws_security_group" "openvpn" {
   name   = "${var.prefix}${var.name}"
   vpc_id = "${var.vpc_id}"
   ingress {
-    from_port = 22
-    to_port   = 22
+    from_port = "${var.ssh_port}"
+    to_port   = "${var.ssh_port}"
     protocol  = "tcp"
     self      = true
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -54,3 +54,8 @@ output "ssh_key" {
   sensitive = false
   value     = "${var.keyname}"
 }
+
+output "ssh_port" {
+  sensitive = false
+  value     = "${var.ssh_port}"
+}

--- a/templates/cloud-config/init.tpl
+++ b/templates/cloud-config/init.tpl
@@ -19,6 +19,7 @@ write_files:
       echo "  instance: ${hostname}.${domain}"
       sudo /usr/local/bin/ovpn_initpki -c ${hostname}.${domain}
       sudo /usr/local/bin/ovpn_config -u udp://${hostname}.${domain}:1194 ${openvpn_args} -E -S
+      sudo chown nobody:nobody /etc/openvpn/crl.pem
       echo "=== All Done ==="
     path: /tmp/setup_openvpn.sh
     permissions: '0755'

--- a/variables.tf
+++ b/variables.tf
@@ -43,6 +43,12 @@ variable "keyname" {
   type        = "string"
 }
 
+variable "ssh_port" {
+  description = "The SSH port, as defined in the original AMI from packer"
+  default     = "222"
+  type        = "string"
+}
+
 variable "name" {
   description = "The main name that will be used for the OpenVPN instance."
   default     = "openvpn"


### PR DESCRIPTION
The original AMI uses ssh port 222 by default, make the port configuration optional.  Also, chown crl.pem to nobody or the default openvpn configuration will fail the first time a client attempts to connect