### PR TITLE
[issue] Fixed subnet ids - invalid number for index got -1 error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "aws_instance" "openvpn" {
   instance_type               = "${var.instance_type}"
   key_name                    = "${var.keyname}"
   source_dest_check           = false
-  subnet_id                   = "${element(var.subnet_ids, count.index - 1)}"
+  subnet_id                   = "${element(var.subnet_ids, count.index)}"
   user_data                   = "${element(data.template_file.openvpn.*.rendered, count.index)}"
   vpc_security_group_ids      = ["${aws_security_group.openvpn.id}","${aws_security_group.openvpn_public.id}","${var.extra_security_group_id}"]
   root_block_device {


### PR DESCRIPTION
Hey,

Thanks for OpenVPN module!  

During usage module with Terraform v0.11.7 I got a below error:

```
Error: Error refreshing state: 1 error(s) occurred:
* module.openvpn.aws_instance.openvpn: 1 error(s) occurred:
* module.openvpn.aws_instance.openvpn: element: invalid number for index, got -1 in:
${element(var.subnet_ids, count.index - 1)}
```
In the configuration file, I am including subnets from VPC module. 

```
subnet_ids                 = ["${module.vpc.public_subnets}", "${module.vpc.private_subnets}"]
``` 

Please review fix.